### PR TITLE
Handle Odd Sensor rates in sds-view.py

### DIFF
--- a/utilities/SDS-View/sds-view.py
+++ b/utilities/SDS-View/sds-view.py
@@ -136,6 +136,11 @@ def plotData(all_data, data_desc, freq, title):
 
         # Generate timestamps using number of data points and sampling frequency
         t = np.arange(0, len(data) / freq, 1 / freq)
+        if len(t) > len(data):
+            # We ended up with some odd round-off on the number of data points
+            # truncate timestamps back down to match the number of data points 
+            # so Matplotlib works.
+            t = t[0:len(data)]
         plt.plot(t, scaled_data, label=desc["value"])
 
         # Store data points in a dictionary for later use when there are 3 axes described

--- a/utilities/SDS-View/sds-view.py
+++ b/utilities/SDS-View/sds-view.py
@@ -137,9 +137,7 @@ def plotData(all_data, data_desc, freq, title):
         # Generate timestamps using number of data points and sampling frequency
         t = np.arange(0, len(data) / freq, 1 / freq)
         if len(t) > len(data):
-            # We ended up with some odd round-off on the number of data points
-            # truncate timestamps back down to match the number of data points 
-            # so Matplotlib works.
+            # Truncate timestamps to match the number of data points
             t = t[0:len(data)]
         plt.plot(t, scaled_data, label=desc["value"])
 


### PR DESCRIPTION
With arbitrary sized data recordings and odd sensor frequencies (e.g. 417 Hz), the created length of timestamps for Matplotlib viewing can mismatch by 1.  Truncate the timestamps to avoid the issues so matplotlib will plot the data.